### PR TITLE
Add "Preview Feature" contribution to extension manifest

### DIFF
--- a/src/Apps/BugBashPro/vss-extension.json
+++ b/src/Apps/BugBashPro/vss-extension.json
@@ -47,6 +47,29 @@
                     "light": "asset://images/hublogo.png",
                     "dark": "asset://images/hublogo_dark.png"
                 }
+            },
+            "constraints": [
+                {
+                    "name": "Feature",
+                    "properties": {
+                        "featureId": "mohitbagra.bugbashpro.bugbash-feature"
+                    }
+                }
+            ]
+        },
+        {
+            "id": "bugbash-feature",
+            "type": "ms.vss-web.feature",
+            "description": "Enable the Bug Bash Pro tool.",
+            "targets": [
+                "ms.vss-web.managed-features",
+                "ms.vss-web.managed-features-onprem"
+            ],
+            "properties": {
+                "name": "Bug Bash Pro",
+                "userConfigurable": true,
+                "hostConfigurable": true,
+                "defaultState": true
             }
         }
     ]


### PR DESCRIPTION
Our team would like to be able to leverage "Preview Features" in Azure DevOps so that the extension does not show up on all projects.

Setting defaultState to true, so that there should be no impact to existing users of the extension. 